### PR TITLE
Fix error non-void function and usage of non-standard port

### DIFF
--- a/src/modbusSlave.h
+++ b/src/modbusSlave.h
@@ -46,6 +46,7 @@ public:
             return C.at(_coilAddress);
         } else {
             ofLogError("ofxModbusTCP Slave:"+ofToString(idNumber)+" on "+masterIP)<<"Get Slave Coil Exceeds Size";
+            return 0;
         }
     }
     int getRegister (int _registerAddress) {
@@ -53,6 +54,7 @@ public:
             return R.at(_registerAddress);
         } else {
             ofLogError("ofxModbusTCP Slave:"+ofToString(idNumber)+" on "+masterIP)<<"Get Slave Register Exceeds Size";
+            return 0;
         }
     }
     

--- a/src/ofxModbusTcpClient.cpp
+++ b/src/ofxModbusTcpClient.cpp
@@ -70,9 +70,18 @@ void ofxModbusTcpClient::setup(string _ip, int _numberOfSlaves) {
     ofLogVerbose("ofxModbusTCP IP:"+ip)<<"Setup with "<<numberOfSlaves<<" slaves";
     setupSlaves();
 }
+
 void ofxModbusTcpClient::setup(string _ip) {
     ip = _ip;
     numberOfSlaves = 1;
+    ofLogVerbose("ofxModbusTCP IP:"+ip)<<"Setup with "<<numberOfSlaves<<" slaves";
+    setupSlaves();
+}
+void ofxModbusTcpClient::setup(string _ip, int _numberOfSlaves, int _port) {
+    ip = _ip;
+    port = _port;
+    numberOfSlaves = _numberOfSlaves;
+    if (numberOfSlaves == 0 || numberOfSlaves > 247) { numberOfSlaves = 1; }
     ofLogVerbose("ofxModbusTCP IP:"+ip)<<"Setup with "<<numberOfSlaves<<" slaves";
     setupSlaves();
 }

--- a/src/ofxModbusTcpClient.cpp
+++ b/src/ofxModbusTcpClient.cpp
@@ -362,6 +362,8 @@ bool ofxModbusTcpClient::getCoil(int _id, int _startAddress) {
     if (enabled) {
         if (_id>0 && _id < slaves.size() && _startAddress < numOfCoils) {
             return slaves.at(_id-1)->getCoil(_startAddress);
+        } else {
+            return false;
         }
     } else {
         return false;
@@ -371,6 +373,8 @@ int ofxModbusTcpClient::getRegister(int _id, int _startAddress) {
     if (enabled ) {
         if (_id>0 && _id < slaves.size() && _startAddress < numOfRegisters) {
             return slaves.at(_id-1)->getRegister(_startAddress);
+        } else {
+            return 0;
         }
     } else {
         return 0;

--- a/src/ofxModbusTcpClient.h
+++ b/src/ofxModbusTcpClient.h
@@ -49,6 +49,7 @@ public:
     
     void setup(string _ip, int _numberOfSlaves);
     void setup(string _ip);
+    void setup(string _ip, int _numberOfSlaves, int _port);
     
     void connect();
     void disconnect();


### PR DESCRIPTION
With following settings:
- Ubuntu 22.04.1 LTS
- of_v0.11.2_linux64gcc6
- Qt Creator 9.0.0 Based on Qt 6.4.1 (GCC 10.3.1 20210422)

we faced these errors:
.../addons/ofxModbusTCP/src/ofxModbusTcpClient.cpp:369: error: control reaches end of non-void function [-Werror=return-type]
.../addons/ofxModbusTCP/src/modbusSlave.h:50: error: control reaches end of non-void function [-Werror=return-type]
.../addons/ofxModbusTCP/src/ofxModbusTcpClient.cpp:378: error: control reaches end of non-void function [-Werror=return-type]
.../addons/ofxModbusTCP/src/modbusSlave.h:57: error: control reaches end of non-void function [-Werror=return-type]

Additionally, we had to use a non-standard port for ModbusTCP.